### PR TITLE
Change defaults regarding package origins

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -37,10 +37,10 @@ patch_run_autoclean: true
 patch_use_unattended_upgrades: true
 
 # Used only if "patch_use_unattended_upgrades: true"
-# Additional package origins to reference, for example:
-# patch_unattended_additional_origins:
-#   - ${distro_id}:${distro_codename}-updates
-#   - ${distro_id}:${distro_codename}-backports
+# Package origins to use:
+patch_unattended_package_origins:
+  - ${distro_id}:${distro_codename}
+  - ${distro_id}:${distro_codename}-security
 
 # Used only if "patch_use_unattended_upgrades: true"
 # Python regular expressions, matching packages to exclude from upgrading, for example:

--- a/templates/50unattended-upgrades.j2
+++ b/templates/50unattended-upgrades.j2
@@ -1,13 +1,7 @@
 Unattended-Upgrade::Allowed-Origins {
-    "${distro_id}:${distro_codename}";
-    "${distro_id}:${distro_codename}-security";
-    "${distro_id}ESMApps:${distro_codename}-apps-security";
-    "${distro_id}ESM:${distro_codename}-infra-security";
-{% if patch_unattended_additional_origins is defined%}
-{% for origin in patch_unattended_additional_origins %}
+{% for origin in patch_unattended_package_origins %}
     "{{ origin }}";
 {% endfor %}
-{% endif %}
 };
 
 Unattended-Upgrade::Package-Blacklist {


### PR DESCRIPTION
# Pull Request Description
Changed defaults for unattended-upgrade allowed origins so the configuration is more flexible - no origin is hardcoded in the template itself. 

Breaking change since the template and default variables are changed.

## Change type
- [ ] Bug fix (non-breaking change which fixes a specific issue)
- [ ] New feature (non-breaking change adding new functionality)
- [x] Breaking change (fix or feature that potentially causes existing functionality to fail)
- [ ] Change that does not affect Ansible Role code (Github Actions Workflow, Documentation, or similair)
