### PR TITLE
Moved reboot_timeout to variable, added option to add post_reboot_delay

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -27,6 +27,12 @@ patch_string_to_filter_upgraded_packages: "Upgrade:"
 # Reboot after upgrade if necessary
 patch_reboot: true
 
+# Seconds to wait after the reboot command was successful before attempting to validate the rebooted
+patch_post_reboot_delay: 0
+
+# Maximum seconds to wait for machine to reboot and respond to a test command.
+patch_reboot_timeout: 600
+
 # Run apt autoremove after upgrade
 patch_run_autoremove: true
 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -38,7 +38,8 @@
 
     - name: Reboot and wait for the machine to get back online
       ansible.builtin.reboot:
-        reboot_timeout: 600
+        post_reboot_delay: "{{ patch_post_reboot_delay }}"
+        reboot_timeout: "{{ patch_reboot_timeout }}"
       when: patch_reboot_required.stat.exists
 
 - name: Run apt autoremove


### PR DESCRIPTION
# Pull Request Description
- Moved reboot_timeout to variable, the default stays the same as the previous hardcoded value, but now can be adjusted
- Added option to specify post_reboot_delay, defaults to 0, so no delay (as it previously was)

## Change type
- [ ] Bug fix (non-breaking change which fixes a specific issue)
- [x] New feature (non-breaking change adding new functionality)
- [ ] Breaking change (fix or feature that potentially causes existing functionality to fail)
- [ ] Change that does not affect Ansible Role code (Github Actions Workflow, Documentation, or similair)
